### PR TITLE
Configurable date regular expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,13 @@ plugins:
 		removeDate: true
 ```
 
+You can customize the regular expression used to parse dates from filenames with `dateRegExp`:
+
+```coffee
+plugins:
+  datefromfilename:
+    dateRegExp: /\b(\d{4})-(\d{2})-(\d{2})-/
+```
+
 ## License
 Licensed under the incredibly [permissive](http://en.wikipedia.org/wiki/Permissive_free_software_licence) [MIT License](http://creativecommons.org/licenses/MIT/)

--- a/src/datefromfilename.plugin.coffee
+++ b/src/datefromfilename.plugin.coffee
@@ -1,4 +1,3 @@
-dateRegExp = /\b(\d{4})[-_ ]?(\d{2})[-_ ]?(\d{2})[-_ ]?/
 
 module.exports = (BasePlugin) ->
 
@@ -8,10 +7,11 @@ module.exports = (BasePlugin) ->
     
     config:
       removeDate: false
+      dateRegExp: /\b(\d{4})[-_ ]?(\d{2})[-_ ]?(\d{2})[-_ ]?/
 
     renderBefore: (opts, next) ->
       {collection, templateData} = opts
-      config = @config
+      {removeDate, dateRegExp} = @config
 
       collection.forEach (document) ->  
             
@@ -19,7 +19,7 @@ module.exports = (BasePlugin) ->
         return unless date = document.get('basename').match(dateRegExp)
         
         # Removing date from output filename if necessary
-        if config.removeDate
+        if removeDate
           document.id = document.id.replace(dateRegExp, '')
           document.set('basename', document.get('basename').replace(dateRegExp, ''))
           document.set('outPath', document.get('outPath').replace(dateRegExp, ''))


### PR DESCRIPTION
I'm porting a blog from Tumblr to DocPad and I'd like to preserve existing URLs of the form `post/41935904836/<slug>` generated from documents named `YYYY-MM-DD-<slug>.html.md`.  These documents  have  a custom URL in the YAML head matter.  Trouble is, datefromfilename thinks 41935904 from the URL is the date, not YYYY-MM-DD from the filename, so I end up with documents at `post/836/YYYY-MM-DD-<slug>`.  Yuck.  Customizing the `dateRegExp` to be stricter for my site was the smallest fix.
