### PR TITLE
Fixing #4 - a documents URL property should be set via setUrl()

### DIFF
--- a/src/datefromfilename.plugin.coffee
+++ b/src/datefromfilename.plugin.coffee
@@ -23,7 +23,7 @@ module.exports = (BasePlugin) ->
           document.id = document.id.replace(dateRegExp, '')
           document.set('basename', document.get('basename').replace(dateRegExp, ''))
           document.set('outPath', document.get('outPath').replace(dateRegExp, ''))
-          document.set('url', document.get('url').replace(dateRegExp, ''))
+          document.setUrl(document.get('url').replace(dateRegExp, ''))
 
         # Date from has priority over filename
         unless document.getMeta().get('date')


### PR DESCRIPTION
A documents URL property should be set via the `setUrl()` method, rather than changing the property directly.

Calling setUrl (which in turn calls  addUrl) ensures that the `urls` array is updated correctly, which in turn updates the filesByUrl array, which is ultimately checked when incoming requests are made.
