### PR TITLE
Use earlier event, and update document metadata

### DIFF
--- a/src/datefromfilename.plugin.coffee
+++ b/src/datefromfilename.plugin.coffee
@@ -9,7 +9,7 @@ module.exports = (BasePlugin) ->
       removeDate: false
       dateRegExp: /\b(\d{4})[-_ ]?(\d{2})[-_ ]?(\d{2})[-_ ]?/
 
-    renderBefore: (opts, next) ->
+    contextualizeAfter: (opts, next) ->
       {collection, templateData} = opts
       {removeDate, dateRegExp} = @config
 
@@ -21,8 +21,13 @@ module.exports = (BasePlugin) ->
         # Removing date from output filename if necessary
         if removeDate
           document.id = document.id.replace(dateRegExp, '')
+          document.set('name', document.get('name').replace(dateRegExp, ''))
           document.set('basename', document.get('basename').replace(dateRegExp, ''))
+          document.set('slug', document.get('slug').replace(dateRegExp, ''))
+          document.set('outFilename', document.get('outFilename').replace(dateRegExp, ''))
           document.set('outPath', document.get('outPath').replace(dateRegExp, ''))
+          document.set('relativeBase', document.get('relativeBase').replace(dateRegExp, ''))
+          document.set('relativeOutPath', document.get('relativeOutPath').replace(dateRegExp, ''))
           document.setUrl(document.get('url').replace(dateRegExp, ''))
 
         # Date from has priority over filename


### PR DESCRIPTION
[Fixes #6]

Using an earlier event will allow other Docpad plugins to calculate using the amended metadata (e.g. slug).